### PR TITLE
fixed length type bug

### DIFF
--- a/Python/IMMA.py
+++ b/Python/IMMA.py
@@ -46,9 +46,11 @@ class IMMA:
                 Length     = line[2:4]
                 if( re.search("\S",Length)==None): 
                     Length = None
-                if ( Length != None and Length != 0 ):
-                    Length = int(Length)-4
-                    line = line[4:len(line)]
+                if ( Length != None ):
+                    Length = int(Length)
+                    if ( Length != 0 ):
+                        Length = int(Length)-4
+                        line = line[4:len(line)]
                 if(getAttachment(Attachment)==None ):
                     raise("Bad IMMA string","Unsupported attachment ID "+Attachment)
 


### PR DESCRIPTION
The original code failed when reading dutch data from January 1850 from ICOADS 2.5. It happily read data preceding the dutch data.

In the IF statement, Length was compared to zero, but Length was a string, so it came up false each time even if the string was zero. I think I've fixed this in so far as it now reads the Dutch data (and everything else from 1850) without crashing.
